### PR TITLE
15 q1 not found

### DIFF
--- a/consumer/internal/infra/msgreceiver/msgreceiver.go
+++ b/consumer/internal/infra/msgreceiver/msgreceiver.go
@@ -21,8 +21,7 @@ func Run(ctx context.Context, chout chan msghandler.Request, wg *sync.WaitGroup)
 	// variable RABBIT_SERVER_URL and open the queue "myqueue".
 	subs, err := pubsub.OpenSubscription(ctx, os.Getenv("Q1"))
 	if err != nil {
-		sentry.CaptureMessage(fmt.Sprint(err))
-		log.Panic(err)
+		return err
 	}
 
 	defer func(subs *pubsub.Subscription, ctx context.Context) {
@@ -36,7 +35,6 @@ func Run(ctx context.Context, chout chan msghandler.Request, wg *sync.WaitGroup)
 	for {
 		msg, err := subs.Receive(ctx)
 		if err != nil {
-			sentry.CaptureMessage(fmt.Sprint(err))
 			log.Printf("Receiving message: %v", err)
 			return err
 		}

--- a/consumer/internal/infra/msgreceiver/msgreceiver.go
+++ b/consumer/internal/infra/msgreceiver/msgreceiver.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 	"sync"
 	"tg-svodd-bot/consumer/internal/infra/msghandler"
 
@@ -37,16 +36,7 @@ func Run(ctx context.Context, chout chan msghandler.Request, wg *sync.WaitGroup)
 	for {
 		msg, err := subs.Receive(ctx)
 		if err != nil {
-
 			sentry.CaptureMessage(fmt.Sprint(err))
-			// Осуществляется проверка по содержимому строки ошибки на совпадение текста.
-			// Не нашел способа лучше, без привязки к содержимому строки ошибки.
-			// На самом деле такая ошибка не должна возникать, т.к когда запущен сервер очередей, уже должна быть создана вся структура и очереди
-			// Надо добавить создание очереди q1 на сервисах svodd
-			if strings.Contains(fmt.Sprint(err), "NOT_FOUND - no queue 'q1' in vhost '/'") {
-				log.Printf("failure, restart required: %v", err)
-				os.Exit(1)
-			}
 			log.Printf("Receiving message: %v", err)
 			return err
 		}

--- a/consumer/internal/infra/msgreceiver/msgreceiver.go
+++ b/consumer/internal/infra/msgreceiver/msgreceiver.go
@@ -14,7 +14,7 @@ import (
 	"gocloud.dev/pubsub"
 )
 
-func Run(ctx context.Context, chout chan msghandler.Request, wg *sync.WaitGroup) {
+func Run(ctx context.Context, chout chan msghandler.Request, wg *sync.WaitGroup) error {
 	defer wg.Done()
 
 	// pubsub.OpenSubscription creates a *pubsub.Subscription from a URL.
@@ -48,7 +48,7 @@ func Run(ctx context.Context, chout chan msghandler.Request, wg *sync.WaitGroup)
 				os.Exit(1)
 			}
 			log.Printf("Receiving message: %v", err)
-			break
+			return err
 		}
 		select {
 		case <-ctx.Done():

--- a/consumer/internal/infra/msgreceiver/msgreceiver.go
+++ b/consumer/internal/infra/msgreceiver/msgreceiver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"sync"
 	"tg-svodd-bot/consumer/internal/infra/msghandler"
 
@@ -36,7 +37,16 @@ func Run(ctx context.Context, chout chan msghandler.Request, wg *sync.WaitGroup)
 	for {
 		msg, err := subs.Receive(ctx)
 		if err != nil {
+
 			sentry.CaptureMessage(fmt.Sprint(err))
+			// Осуществляется проверка по содержимому строки ошибки на совпадение текста.
+			// Не нашел способа лучше, без привязки к содержимому строки ошибки.
+			// На самом деле такая ошибка не должна возникать, т.к когда запущен сервер очередей, уже должна быть создана вся структура и очереди
+			// Надо добавить создание очереди q1 на сервисах svodd
+			if strings.Contains(fmt.Sprint(err), "NOT_FOUND - no queue 'q1' in vhost '/'") {
+				log.Printf("failure, restart required: %v", err)
+				os.Exit(1)
+			}
 			log.Printf("Receiving message: %v", err)
 			break
 		}

--- a/consumer/main.go
+++ b/consumer/main.go
@@ -48,8 +48,11 @@ func main() {
 
 	go func() {
 		err := msgreceiver.Run(ctx, ch, wg)
+		// Обрабатываем ошибку и выходим с кодом 1, для того чтобы инициировать перезапуск докер контейнера.
+		// Возможно тут имеет смысл сделать сервис проверки health, но пока так
 		if err != nil {
-			log.Printf("failure, restart required: %v", err)
+			log.Printf("%v\r\n failure, restart required", err)
+			sentry.CaptureMessage(fmt.Sprint(err))
 			os.Exit(1)
 		}
 	}()

--- a/consumer/main.go
+++ b/consumer/main.go
@@ -21,31 +21,45 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 
-	contents, err := os.ReadFile(os.Getenv("SENTRY_DSN_FILE"))
-	if err != nil {
-		log.Fatalf("can not read SENTRY_DSN_FILE")
-	}
-	dsn := fmt.Sprintf("%v", strings.Trim(string(contents), "\r\n"))
+	mode := os.Getenv("APP_ENV")
 
-	err = sentry.Init(sentry.ClientOptions{
-		Dsn: dsn,
-		// Set TracesSampleRate to 1.0 to capture 100%
-		// of transactions for performance monitoring.
-		// We recommend adjusting this value in production,
-		TracesSampleRate: 1.0,
-	})
-	if err != nil {
-		log.Fatalf("sentry.Init: %s", err)
+	if mode == "prod" {
+		contents, err := os.ReadFile(os.Getenv("SENTRY_DSN_FILE"))
+		if err != nil {
+			log.Fatalf("can not read SENTRY_DSN_FILE")
+		}
+		dsn := fmt.Sprintf("%v", strings.Trim(string(contents), "\r\n"))
+
+		err = sentry.Init(sentry.ClientOptions{
+			Dsn: dsn,
+			// Set TracesSampleRate to 1.0 to capture 100%
+			// of transactions for performance monitoring.
+			// We recommend adjusting this value in production,
+			TracesSampleRate: 1.0,
+		})
+		if err != nil {
+			log.Fatalf("sentry.Init: %s", err)
+		}
 	}
 
 	ch := make(chan msghandler.Request, 100)
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
-	go msgreceiver.Run(ctx, ch, wg)
+
+	go func() {
+		err := msgreceiver.Run(ctx, ch, wg)
+		if err != nil {
+			log.Printf("failure, restart required: %v", err)
+			os.Exit(1)
+		}
+	}()
+
 	go msghandler.Handler(ctx, ch, wg)
 
-	// Flush buffered events before the program terminates.
-	defer sentry.Flush(2 * time.Second)
+	if mode == "PROD" {
+		// Flush buffered events before the program terminates.
+		defer sentry.Flush(2 * time.Second)
+	}
 
 	wg.Wait()
 	stop()

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -29,7 +29,7 @@ services:
       restart_policy:
         condition: on-failure
         delay: 5s
-        max_attempts: 5
+#        max_attempts: 5
         window: 120s
 
 secrets:

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -13,6 +13,7 @@ services:
       - rmq-net
       - tg-bot-net
     environment:
+      APP_ENV: prod
       RABBIT_SERVER_URL: amqp://rmq
       RABBIT_EXCHANGE_NAME: ex1
       TG_CHAT_ID: "@svoddru"

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -29,8 +29,8 @@ services:
         constraints: [ node.role == manager ]
       restart_policy:
         condition: on-failure
-        delay: 5s
-#        max_attempts: 5
+        delay: 10s
+        max_attempts: 5
         window: 120s
 
 secrets:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - rmq-net
       - tg-bot-net
     environment:
+      APP_ENV: dev
       RABBIT_SERVER_URL: amqp://rmq
       RABBIT_EXCHANGE_NAME: ex1
       TG_CHAT_ID: "-1001700331408"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,9 +36,6 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
-        delay: 5s
-#        max_attempts: 5
-        window: 120s
 
 secrets:
   tg_bot_token:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       restart_policy:
         condition: on-failure
         delay: 5s
-        max_attempts: 5
+#        max_attempts: 5
         window: 120s
 
 secrets:


### PR DESCRIPTION
Добавлено условие проверки ошибки, отсутствия очереди на сервере сообщений, в случае отсутствия производится выход из системы для перезапуска контейнера.
Удален параметр отвечающий за кол-во поток рестарта сервиса max_attempts, таким образом докер всегда будет пытаться перезапустить сломанный контейнер (в случае ошибки).

Есть идея добавить на сервис svodd cli-php функцию, которая при старте будет создавать очередь. Сейчас он это делает только, когда поступил новый комментарий. Поэтом возникают случаи, когда запуск всех систем состоялся и успешен, но очередь еще не создана, т.к. после рестарта не было еще новых сообщений. Надо принудительно при рестарте системы проверять и создавать очередь. тогда шанс возникновения такой ошибки будет сведен к минимуму
