### PR TITLE
fixed read: connection reset by peer, added resending

### DIFF
--- a/consumer/internal/infra/msgsender/msgsender.go
+++ b/consumer/internal/infra/msgsender/msgsender.go
@@ -38,12 +38,19 @@ func Send(ctx context.Context, messages []string, headers map[string]string) {
 			ParseMode: "HTML",
 		}
 
-		err := sendMessage(tgUrl, msg)
-		if err != nil {
-			cm := fmt.Sprintf("error: %v Text: %s", err, msg.Text)
-			log.Println(cm)
-			sentry.CaptureMessage(cm)
+		for i := 1; i <= 5; i++ {
+			// Делаем 5 попыток отправки, если получена ошибка, если нет, то цикл сразу завершается
+			err := sendMessage(tgUrl, msg)
+			if err != nil {
+				cm := fmt.Sprintf("error: %v Text: %s", err, msg.Text)
+				log.Println(cm)
+				sentry.CaptureMessage(cm)
+				time.Sleep(time.Second * 3)
+				continue
+			}
+			break
 		}
+
 		// Ожидаем 3 секунды после отправки, необходимо для соблюдения лимитов отправки сообщений ботом, 20 сообщений в минуту
 		time.Sleep(time.Second * 3)
 	}


### PR DESCRIPTION
Попытка исправить ошибку при отправке сообщений.
Участились случаи, когда телеграм отдает ошибку: `read: connection reset by peer` при попытке отправит сообщение.

https://svodd.sentry.io/issues/5032817463/

TG-SVODD-BOT-1P, TG-SVODD-BOT-1Q,TG-SVODD-BOT-1R,G-SVODD-BOT-1S,TG-SVODD-BOT-1T,TG-SVODD-BOT-1V,TG-SVODD-BOT-1W,TG-SVODD-BOT-1X,TG-SVODD-BOT-1Y,TG-SVODD-BOT-1Z,TG-SVODD-BOT-20,TG-SVODD-BOT-21,TG-SVODD-BOT-22,TG-SVODD-BOT-23

Функция отправки теперь обернута в цикл из 5 шагов, если будет получена ошибка при отправке, то функция ожидает 3 секунды и отправляет сообщение снова и так до истечения лимита 5 раз.