### PR TITLE
Улучшение обработки цитируемого отрезка

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ down:
 	docker compose down --remove-orphans
 up:
 	docker compose up --build -d
-
+test:
+	go test -v ./...
 check:
 	golangci-lint run -v
 

--- a/consumer/internal/infra/msgparser/msgparser.go
+++ b/consumer/internal/infra/msgparser/msgparser.go
@@ -227,7 +227,25 @@ func (p *Parser) truncateText(text string) string {
 	}
 
 	if utf8.RuneCountInString(truncatedText) < count {
-		return truncatedText + "…"
+		return ModifyString(strings.TrimSpace(truncatedText))
 	}
 	return truncatedText
+}
+
+// ModifyString replaces the last punctuation mark in the input string with an ellipsis.
+// It checks the last character of a string and replaces it with "…"
+// if it's present in a specified list, otherwise it appends "…" to the end of the string:
+func ModifyString(input string) string {
+	lastRune, _ := utf8.DecodeLastRuneInString(input)
+	punctuationMarks := []rune{' ', '.', ',', ':', ';', '…', '-', '–', '—', '=', '+'}
+
+	for _, punctuationMark := range punctuationMarks {
+		if lastRune == punctuationMark {
+			modifiedInput := []rune(input)
+			modifiedInput[len(modifiedInput)-1] = '…'
+			return string(modifiedInput)
+		}
+	}
+
+	return input + "…"
 }

--- a/consumer/internal/infra/msgparser/msgparser_test.go
+++ b/consumer/internal/infra/msgparser/msgparser_test.go
@@ -1,0 +1,181 @@
+package msgparser
+
+import (
+	"testing"
+)
+
+func TestTruncateText(t *testing.T) {
+	p := &Parser{maxWords: 6, maxChars: 20}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "within max words limit",
+			input:    "hello world this is a test",
+			expected: "hello world this is a test",
+		},
+		{
+			name:     "within max words limit utf-8",
+			input:    "привет мир запускаем тест для строки",
+			expected: "привет мир запускаем тест для строки",
+		},
+		{
+			name:     "exceeds max words limit, within max chars limit",
+			input:    "hello world this is a test with more words",
+			expected: "hello world this is…",
+		},
+		{
+			name:     "exceeds max words limit, within max chars limit utf-8",
+			input:    "привет мир запускаем тест для строки, в которой еще больше слов",
+			expected: "привет мир…",
+		},
+		{
+			name:     "exceeds both max words and max chars limits",
+			input:    "hello world this is a very long test with many words and characters",
+			expected: "hello world this is…",
+		},
+		{
+			name:     "empty input text",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "single-word input text",
+			input:    "hello",
+			expected: "hello",
+		},
+		{
+			name:     "input text with multiple spaces between words",
+			input:    "hello   world  this  is  a  test",
+			expected: "hello   world  this…",
+		},
+		{
+			name:     "input text with multiple spaces between words utf-8",
+			input:    "привет   мир  запускаем  тест  для  строки",
+			expected: "привет   мир…",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := p.truncateText(tt.input)
+			if actual != tt.expected {
+				t.Errorf("truncateText(%q) = %q, want %q", tt.input, actual, tt.expected)
+			}
+		})
+	}
+}
+
+func TestModifyString(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "Привет, мир ",
+			expected: "Привет, мир…",
+		},
+		{
+			input:    "Привет, мир.",
+			expected: "Привет, мир…",
+		},
+		{
+			input:    "Привет, мир,",
+			expected: "Привет, мир…",
+		},
+		{
+			input:    "Привет, мир:",
+			expected: "Привет, мир…",
+		},
+		{
+			input:    "Привет, мир;",
+			expected: "Привет, мир…",
+		},
+		{
+			input:    "Привет, мир…",
+			expected: "Привет, мир…",
+		},
+		{
+			input:    "Привет, мир-",
+			expected: "Привет, мир…",
+		},
+		{
+			input:    "Привет, мир–",
+			expected: "Привет, мир…",
+		},
+		{
+			input:    "Привет, мир—",
+			expected: "Привет, мир…",
+		},
+		{
+			input:    "Привет, мир=",
+			expected: "Привет, мир…",
+		},
+		{
+			input:    "Привет, мир+",
+			expected: "Привет, мир…",
+		},
+		{
+			input:    "Привет, мир",
+			expected: "Привет, мир…",
+		},
+		{
+			input:    "Hello, world ",
+			expected: "Hello, world…",
+		},
+		{
+			input:    "Hello, world.",
+			expected: "Hello, world…",
+		},
+		{
+			input:    "Hello, world,",
+			expected: "Hello, world…",
+		},
+		{
+			input:    "Hello, world:",
+			expected: "Hello, world…",
+		},
+		{
+			input:    "Hello, world;",
+			expected: "Hello, world…",
+		},
+		{
+			input:    "Hello, world…",
+			expected: "Hello, world…",
+		},
+		{
+			input:    "Hello, world-",
+			expected: "Hello, world…",
+		},
+		{
+			input:    "Hello, world–",
+			expected: "Hello, world…",
+		},
+		{
+			input:    "Hello, world—",
+			expected: "Hello, world…",
+		},
+		{
+			input:    "Hello, world=",
+			expected: "Hello, world…",
+		},
+		{
+			input:    "Hello, world+",
+			expected: "Hello, world…",
+		},
+		{
+			input:    "Hello, world",
+			expected: "Hello, world…",
+		},
+	}
+
+	for _, test := range tests {
+		result := ModifyString(test.input)
+		if result != test.expected {
+			t.Errorf("ModifyString(%q) = %q, expected %q", test.input, result, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
Добавлена функция ModifyText, которая проверяет последний символ строки и заменяет его на "…",  если он присутствует в указанном списке, в противном случае просто добавляет "…" в конец строки:
`[]rune{' ', '.', ',', ':', ';', '…', '-', '–', '—', '=', '+'}`

Т.к. мы работаем с кириллицей в utf-8, то функция переводит строку в срез рун. Руны используются для работы с юникодными символами. Руна (Rune) - это целое число типа int32, которое представляет отдельный символ. Функция работает с числами. 

Добавлены автоматические тесты для функций truncateText — ограничение размера цитируемого отрывка и ModifyText — добавление многоточия к цитируемому отрывку.

issue #27 
https://github.com/terratensor/tg-svodd-bot/issues/27#issuecomment-2267503237
https://github.com/terratensor/tg-svodd-bot/issues/27#issuecomment-2267514883