### PR TITLE
Улучшена логика парсера

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,35 @@ RABBIT_SERVER_URL=amqp://localhost go run .
 ```
 RABBIT_SERVER_URL=amqp://localhost Q1=rabbit://q1 go run ./consumer/.
 ```
+
+# development
+
+Запускаем локально svodd-rabbitmq
+
+http://127.0.0.1:15672/#/
+guest
+guest
+
+Запускаем tg-bot
+
+```
+make up
+```
+
+или
+```
+docker compose up --build -d
+```
+
+Для отладки запускаем локально svodd (fct-search)
+
+Устанавливает текущую активнцю тему, запускаем парсер
+```
+./app/bin/fct-parser.linux.amd64 -j -h -o ./app/data/ 
+```
+
+Запускаем Updater для записи сообщение а БД
+```
+docker compose run --rm cli-php php yii index/updating-index
+```
+

--- a/consumer/internal/infra/msghandler/msghandler.go
+++ b/consumer/internal/infra/msghandler/msghandler.go
@@ -34,7 +34,7 @@ func Handler(ctx context.Context, ch chan Request, wg *sync.WaitGroup, tgmessage
 			// Обрабатываем комментарий, заменяем, удаляем не поддерживаемые теги,
 			// форматируем и разбиваю на блоки не превышающие 4096 символов,
 			// для отправки в телеграм
-			messages, err := parser.Parse(r.Message)
+			messages, err := parser.Parse(r.Message, r.Headers)
 			if err != nil {
 				sentry.CaptureMessage(fmt.Sprint(err))
 				log.Printf("error: %v Text: %s", err, r.Message)

--- a/consumer/internal/infra/msgparser/msgparser.go
+++ b/consumer/internal/infra/msgparser/msgparser.go
@@ -479,7 +479,11 @@ func formatText(nodes []Chunk, builder *strings.Builder) {
 		}
 		// Обрабатываем узлы текста
 		if node.Type == Text {
-			builder.WriteString(strings.TrimSpace(node.Text) + "\n")
+			builder.WriteString(strings.TrimSpace(node.Text))
+			// Если следующий узел не Inline ссылка, добавляем перенос строки
+			if len(nodes) > n+1 && nodes[n+1].Type != Inline {
+				builder.WriteString("\n")
+			}
 			flag = 0
 		}
 		// Обрабатываем узлы блок-цитаты

--- a/consumer/internal/infra/msgparser/msgparser.go
+++ b/consumer/internal/infra/msgparser/msgparser.go
@@ -474,7 +474,7 @@ func formatText(nodes []Chunk, builder *strings.Builder) {
 		log.Printf("node: %+v\n", node)
 		// Обрабатываем узлы переноса строки
 		if node.Type == LineBreak {
-			// Если предыдущий узел не Inline, добавляем пробел
+			// Если 2 предыдущих узла не Inline, добавляем перенос строки
 			if flag > 1 {
 				continue
 			}
@@ -502,13 +502,13 @@ func formatText(nodes []Chunk, builder *strings.Builder) {
 		}
 		// Обрабатываем узлы ссылки
 		if node.Type == Inline {
-			// Если предыдущий узел не Inline, добавляем пробел перед ссылкой
-			if n-1 > -1 && nodes[n-1].Type != Inline {
+			// Если предыдущий узел не LineBreak перенос строки, добавляем пробел перед ссылкой
+			if n-1 > -1 && nodes[n-1].Type != LineBreak {
 				builder.WriteString(" ")
 			}
 			builder.WriteString(node.Text)
-			// Если следующий узел не Inline, добавляем пробел после ссылки
-			if len(nodes) > n+1 && nodes[n+1].Type != Inline {
+			// Если следующий узел не LineBreak перенос строки, добавляем пробел после ссылки
+			if len(nodes) > n+1 && nodes[n+1].Type != LineBreak {
 				builder.WriteString(" ")
 			}
 			flag = 0

--- a/consumer/internal/infra/msgparser/msgparser.go
+++ b/consumer/internal/infra/msgparser/msgparser.go
@@ -77,8 +77,14 @@ func (p *Parser) Parse(msg string, headers map[string]string) ([]string, error) 
 			nodes = append(nodes, Chunk{Text: "\n", Type: LineBreak})
 			return
 		}
+		// Обрамляем цитату нодами переноса строк, 
+		//если далее в процессе парсинга образуются дополнительные переносы,
+		// они будут удален функцией formatText
 		if n.Type == html.ElementNode && n.Data == "blockquote" {
+			nodes = append(nodes, Chunk{Text: "\n", Type: LineBreak})
+			nodes = append(nodes, Chunk{Text: "\n", Type: LineBreak})
 			nodes = append(nodes, Chunk{Text: p.processBlockquote(n), Type: Blockquote})
+			nodes = append(nodes, Chunk{Text: "\n", Type: LineBreak})
 			nodes = append(nodes, Chunk{Text: "\n", Type: LineBreak})
 			return
 		}

--- a/consumer/internal/infra/msgparser/msgparser.go
+++ b/consumer/internal/infra/msgparser/msgparser.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"tg-svodd-bot/consumer/internal/infra/msgsign"
@@ -283,8 +284,10 @@ func ModifyString(input string) string {
 // It returns a slice of message strings and an error if the generated message is empty.
 func splitMessageBySentences(chunk string, msgsign *msgsign.Sign, limit int) ([]string, error) {
 	var msgs []string
-	// sentences []string Делим параграф на предложения, разделитель точка
-	sentences := strings.SplitAfter(chunk, ".")
+
+	// sentences := strings.SplitAfter(chunk, ".")
+    re := regexp.MustCompile(`[.?!]\s+`)
+    sentences := re.Split(chunk, -1)
 
 	var builder strings.Builder
 

--- a/consumer/internal/infra/msgparser/msgparser.go
+++ b/consumer/internal/infra/msgparser/msgparser.go
@@ -187,7 +187,7 @@ func (p *Parser) processBlockquote(node *html.Node) string {
 		if el.Type == html.ElementNode && nodeHasRequiredCssClass("link", el) {
 			link := getInnerText(el)
 			link = tgLinkClipper(link)
-			text += fmt.Sprintf(" %v", link)
+			text += fmt.Sprintf(" %v ", link)
 		}
 	}
 

--- a/consumer/internal/infra/msgparser/msgparser.go
+++ b/consumer/internal/infra/msgparser/msgparser.go
@@ -477,7 +477,7 @@ func formatText(nodes []Chunk, builder *strings.Builder) {
 	builder.Reset()
 	flag := 0
 	for n, node := range nodes {
-		log.Printf("node: %+v\n", node)
+		// log.Printf("node: %+v\n", node)
 		// Обрабатываем узлы переноса строки
 		if node.Type == LineBreak {
 			// Если 2 предыдущих узла не Inline, добавляем перенос строки

--- a/consumer/internal/infra/msgparser/msgparser.go
+++ b/consumer/internal/infra/msgparser/msgparser.go
@@ -77,8 +77,8 @@ func (p *Parser) Parse(msg string, headers map[string]string) ([]string, error) 
 			nodes = append(nodes, Chunk{Text: "\n", Type: LineBreak})
 			return
 		}
-		// Обрамляем цитату нодами переноса строк, 
-		//если далее в процессе парсинга образуются дополнительные переносы,
+		// Обрамляем цитату нодами переноса строк,
+		// если далее в процессе парсинга образуются дополнительные переносы,
 		// они будут удален функцией formatText
 		if n.Type == html.ElementNode && n.Data == "blockquote" {
 			nodes = append(nodes, Chunk{Text: "\n", Type: LineBreak})

--- a/consumer/internal/infra/msgparser/msgparser_test.go
+++ b/consumer/internal/infra/msgparser/msgparser_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestTruncateText(t *testing.T) {
-	p := &Parser{maxWords: 6, maxChars: 20}
+	p := &Parser{quoteMaxWords: 6, quoteMaxChars: 20}
 
 	tests := []struct {
 		name     string

--- a/consumer/internal/infra/msgsender/msgsender.go
+++ b/consumer/internal/infra/msgsender/msgsender.go
@@ -45,7 +45,6 @@ func Send(ctx context.Context, messages []string, headers map[string]string, tgm
 		token)
 	chatID := os.Getenv("TG_CHAT_ID")
 
-	link := headers["comment_link"]
 	// Парсим ID комментария
 	commentID, err := strconv.Atoi(headers["comment_id"])
 	if err != nil {
@@ -53,11 +52,7 @@ func Send(ctx context.Context, messages []string, headers map[string]string, tgm
 		commentID = 0
 	}
 
-	for n, text := range messages {
-
-		if len(messages) == n+1 {
-			text = fmt.Sprintf("%v\n\n★ <a href=\"%v\">Источник</a>", text, link)
-		}
+	for _, text := range messages {
 
 		msg := &message.Message{
 			ChatID:    chatID,

--- a/consumer/internal/infra/msgsign/msgsign.go
+++ b/consumer/internal/infra/msgsign/msgsign.go
@@ -1,0 +1,19 @@
+package msgsign
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+type Sign struct {
+	Value string
+	Len   int
+}
+
+func New(headers map[string]string) *Sign {
+	link := headers["comment_link"]
+	value := fmt.Sprintf("\n\n★ <a href=\"%v\">Источник</a>", link)
+
+	sign := Sign{Value: value, Len: utf8.RuneCountInString(value)}
+	return &sign
+}

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   tg-svodd-bot:
     image: ${REGISTRY}/tg-svodd-bot:${IMAGE_TAG}

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -24,6 +24,7 @@ services:
       POSTGRES_DB: ${APP_POSTGRES_DB}
       QUOTE_MAX_WORDS: 40
       QUOTE_MAX_CHARS: 350
+      MSG_MAX_CHARS: 4096
     secrets:
       - tg_bot_token
       - sentry_dsn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       POSTGRES_DB: app
       QUOTE_MAX_WORDS: 40
       QUOTE_MAX_CHARS: 350
+      MSG_MAX_CHARS: 4096
     secrets:
       - tg_bot_token
       - sentry_dsn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   registry:
     image: registry:2


### PR DESCRIPTION
### Ещё в разработке, not merge
#36 связанный issue

- Добавлен параметр MSG_MAX_CHARS по умолчанию 4096, взято из спецификации телеги максимальная длина сообщения
- Теперь длина блока (чанка) при превышении максимальной длины сообщения, считается с учетом подписи к сообщению
- Подпись к сообщению вынесена в отдельную функцию и перенесена в парсер
- Добавлена обработка сценария, когда сообщение превышает максимальную длину, и при разбиении на чанки по разделителю строки `\n` получен 1 чанк, длина которого всё еще превышает допустимую. Например, сообщение простыней без единого переноса строки. Такое сообщение разбивается по предложениям, с помощью новой функции разбиения по разделителю строки `.`

В процессе. Добавить обработку сценария, когда после предыдущих двух функция, все ещё получен чанк превышающий допустимые размеры. Например, сообщение без единой точки, в одно предложение, простыня, поток мысли, спам и т.д.
Добавить функцию, которая будет разбивать сообщение по словам (токенам) на чанки.

Если же и после обработки этой функции будет получен чанк, длина которого превышает допустимую, то это означает, что 4096 символов написаны без единого пробела, что скорее всего спам, бинарник, шифр, что-то еще? Предлагаю такое сообщение не публиковать, ну или разбивать по буквам. что  по идее не сложно. будет такой мега парсер) 

В процессе. Поправить переносы строк в цитатах